### PR TITLE
Prioritize More Specific Tags

### DIFF
--- a/content/akashi-white-oak.md
+++ b/content/akashi-white-oak.md
@@ -9,8 +9,8 @@ authors:
   - jordan-hawker
 date: Tues Mar 02 2021 19:53:40 GMT-0800 (Pacific Standard Time)
 tags:
-  - whiskey
   - japanese
+  - whiskey
 meta:
   ratings:
     nose: 2

--- a/content/barrell-dovetail-2019.md
+++ b/content/barrell-dovetail-2019.md
@@ -9,8 +9,8 @@ authors:
   - jordan-hawker
 date: Thu Mar 25 2021 19:28:40 GMT-0700 (Pacific Daylight Time)
 tags:
-  - whiskey
   - american
+  - whiskey
 meta:
     ratings:
       nose: 2

--- a/content/caol-ila-8-2010.md
+++ b/content/caol-ila-8-2010.md
@@ -9,9 +9,9 @@ authors:
   - jordan-hawker
 date: Sat Mar 13 2021 18:03:48 GMT-0800 (Pacific Standard Time)
 tags:
-  - whiskey
   - scotch
   - islay
+  - whiskey
 meta:
   ratings:
     nose: 3.5

--- a/content/hudson-single-malt.md
+++ b/content/hudson-single-malt.md
@@ -9,8 +9,8 @@ authors:
   - jordan-hawker
 date: Sat Feb 27 2021 19:52:48 GMT-0800 (Pacific Standard Time)
 tags:
-  - whiskey
   - american
+  - whiskey
 meta:
   ratings:
     nose: 3.5

--- a/content/makers-mark.md
+++ b/content/makers-mark.md
@@ -9,9 +9,9 @@ authors:
   - jordan-hawker
 date: Thurs Feb 25 2021 19:12:40 GMT-0800 (Pacific Standard Time)
 tags:
-  - whiskey
-  - american
   - bourbon
+  - american
+  - whiskey
 meta:
   ratings:
     nose: 3

--- a/content/uncle-nearest-1884.md
+++ b/content/uncle-nearest-1884.md
@@ -9,8 +9,8 @@ authors:
   - jordan-hawker
 date: Mon Mar 8 2021 19:37:48 GMT-0800 (Pacific Standard Time)
 tags:
-  - whiskey
   - american
+  - whiskey
 meta:
   ratings:
     nose: 2.5

--- a/content/woodford-reserve-distiller's-select.md
+++ b/content/woodford-reserve-distiller's-select.md
@@ -9,9 +9,9 @@ authors:
   - jordan-hawker
 date: Wed Feb 24 2021 17:37:33 GMT-0800 (Pacific Standard Time)
 tags:
-  - whiskey
-  - american
   - bourbon
+  - american
+  - whiskey
 meta:
   ratings:
     nose: 2


### PR DESCRIPTION
Since only one tag gets displayed at the top of a post, use the most specific tag at the top of the frontmatter metadata so that it gets displayed.